### PR TITLE
Initial review PR

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,9 +35,6 @@ Installing from PyPI
 .. note:: This library is not available on PyPI yet. Install documentation is included
    as a standard element. Stay tuned for PyPI availability!
 
-.. todo:: Remove the above note if PyPI version is/will be available at time of release.
-   If the library is not planned for PyPI, remove the entire 'Installing from PyPI' section.
-
 On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
 PyPI <https://pypi.org/project/adafruit-circuitpython-airlift/>`_. To install for current user:
 
@@ -63,7 +60,14 @@ To install in a virtual environment in your current project:
 Usage Example
 =============
 
-.. todo:: Add a quick, simple example. It and other examples should live in the examples folder and be included in docs/examples.rst.
+Example::
+
+  from adafruit_airlift.esp32 import ESP32
+  import _bleio
+
+  esp32 = ESP32(debug=True)
+  _bleio.set_adapter(esp32.start_bluetooth())
+
 
 Contributing
 ============

--- a/adafruit_airlift/__init__.py
+++ b/adafruit_airlift/__init__.py
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
 # SPDX-FileCopyrightText: Copyright (c) 2020 Dan Halbert for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT

--- a/adafruit_airlift/esp32.py
+++ b/adafruit_airlift/esp32.py
@@ -129,12 +129,12 @@ class ESP32:
     def start_bluetooth(self, uart=None, debug=False):
         """Set up the ESP32 in HCI Bluetooth mode, if it is not already doing something else.
 
-        :param uart busio.UART: `~busio.UART` used for communication with the ESP32.
-          `uart` must have its `baudrate=115200`, `timeout = 0`,
-          and `receiver_buffer_size` at least of size 512.
+        :param uart busio.UART: Used for communication with the ESP32.
+          ``uart`` must have its ``baudrate = 115200``, ``timeout = 0``,
+          and ``receiver_buffer_size`` at least of size 512.
           If not supplied, ``board.TX`` and ``board.RX`` are used to create a suitable UART.
 
-        :return: A `_bleio.Adapter`, to be passed to `_bleio.set_adapter()`.
+        :return: A `_bleio.Adapter`, to be passed to ``_bleio.set_adapter()``.
         """
         # Will fail with ImportError if _bleio is not on the board.
         # That exception is probably good enough.
@@ -184,9 +184,9 @@ class ESP32:
     def start_wifi(self, spi=None):
         """Start WiFi on the ESP32.
 
-        :param spi: `busio.SPI` used for communication with the eSP32.
-          If not supplied, `board.SPI()` is used.
-        :return: the `~busio.SPI` object that will be used.
+        :param spi busio.SPI: Used for communication with the eSP32.
+          If not supplied, ``board.SPI()`` is used.
+        :return: the ``busio.SPI`` object that will be used.
         :rtype: busio.SPI
         """
         self.reset(ESP32.WIFI)

--- a/adafruit_airlift/esp32.py
+++ b/adafruit_airlift/esp32.py
@@ -125,14 +125,15 @@ class ESP32:
         # Everything's fine. Remember mode.
         self._mode = mode
 
-    def start_bluetooth(self, uart=None, debug=False):
+    # pylint: disable=invalid-name
+    def start_bluetooth(self, tx=None, rx=None, debug=False):
         """Set up the ESP32 in HCI Bluetooth mode, if it is not already doing something else.
 
-        :param uart busio.UART: Used for communication with the ESP32.
-          ``uart`` must have its ``baudrate = 115200``, ``timeout = 0``,
-          and ``receiver_buffer_size`` at least of size 512.
-          If not supplied, ``board.TX`` and ``board.RX`` are used to create a suitable UART.
-
+        :param reset ~microcontroller.Pin: ESP32 TX pin for Bluetooth UART communication.
+           If `None`, use ``board.ESP_TX``.
+        :param gpio0 ~microcontroller.Pin: ESP32 RX pin for Bluetooth UART communication.
+           If `None`, use ``board.ESP_RX``.
+        :param debug bool: Print out some debugging information.
         :return: A `_bleio.Adapter`, to be passed to ``_bleio.set_adapter()``.
         """
         # Will fail with ImportError if _bleio is not on the board.
@@ -150,9 +151,9 @@ class ESP32:
         # Choose Bluetooth mode.
         self._chip_select.switch_to_output(False)
 
-        self._uart = uart or busio.UART(
-            board.ESP_TX,
-            board.ESP_RX,
+        self._uart = busio.UART(
+            tx or board.ESP_TX,
+            rx or board.ESP_RX,
             baudrate=115200,
             timeout=0,
             receiver_buffer_size=512,

--- a/adafruit_airlift/esp32.py
+++ b/adafruit_airlift/esp32.py
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
 # SPDX-FileCopyrightText: Copyright (c) 2020 Dan Halbert for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
@@ -189,12 +188,21 @@ class ESP32:
         :return: the ``busio.SPI`` object that will be used.
         :rtype: busio.SPI
         """
+        if self._mode == ESP32.WIFI:
+            # Already started.
+            return self._spi
+
+        if self._mode == ESP32.BLUETOOTH:
+            raise RuntimeError("ESP32 is in Bluetooth mode; use stop_bluetooth() first")
+
         self.reset(ESP32.WIFI)
         self._spi = spi or board.SPI()
         return self._spi
 
     def stop_wifi(self):
         """Stop WiFi on the ESP32.
-        The `busio.SPI` used is not deinitialized.
+        The `busio.SPI` used is not deinitialized, since it may be in use for other devices.
         """
+        if self._mode != ESP32.WIFI:
+            return
         self.reset(ESP32.NOT_IN_USE)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,3 +6,6 @@
 
 .. automodule:: adafruit_airlift
    :members:
+
+.. automodule:: adafruit_airlift.esp32
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,11 +21,10 @@ extensions = [
     "sphinx.ext.todo",
 ]
 
-# TODO: Please Read!
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-# autodoc_mock_imports = ["digitalio", "busio"]
+autodoc_mock_imports = ["board", "digitalio", "busio"]
 
 
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,9 @@ intersphinx_mapping = {
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
 }
 
+# Show the docstring from both the class and its __init__() method
+autoclass_content = "both"
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,14 +23,8 @@ Table of Contents
 .. toctree::
     :caption: Tutorials
 
-.. todo:: Add any Learn guide links here. If there are none, then simply delete this todo and leave
-    the toctree above for use later.
-
 .. toctree::
     :caption: Related Products
-
-.. todo:: Add any product links here. If there are none, then simply delete this todo and leave
-    the toctree above for use later.
 
 .. toctree::
     :caption: Other Links

--- a/examples/airlift_simpletest.py
+++ b/examples/airlift_simpletest.py
@@ -1,3 +1,14 @@
-# SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Dan Halbert, written for Adafruit Industries
 #
 # SPDX-License-Identifier: Unlicense
+
+# Test works for boards with onboard adapters.
+
+import _bleio
+from adafruit_airlift.esp32 import ESP32
+
+esp32 = ESP32()
+adapter = esp32.start_bluetooth()
+_bleio.set_adapter(adapter)  # pylint: disable=no-member
+
+print(_bleio.adapter.address)

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,7 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=[
-        "Adafruit-Blinka",
-        "adafruit-blinka-bleio",
-    ],
+    install_requires=["Adafruit-Blinka", "adafruit-blinka-bleio",],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This is a "fake" PR that will allow review of all the code. DO NOT MERGE.

[GitHub trick for doing this described in https://astrofrog.github.io/blog/2013/04/10/how-to-conduct-a-full-code-review-on-github/]

Note: You pass pins for the basic ESP32 constructor, similar to what the ESP32SPI library does. These are the pins that are used for both SPI and Bluetooth, and for resetting. Then, for Bluetooth, you pass a UART, or it uses a default one. For WiFi, you pass an SPI, or it uses `board.SPI()`.

I also originally wrote a version that took `DigitalInOut`s, with the pin "constructor" calling it, but ultimately was cumbersome, and seemed unnecessary for now.

