### PR TITLE
Avoid AttributeError when calling start_wifi() after stop_bluetooth()

### DIFF
--- a/adafruit_airlift/esp32.py
+++ b/adafruit_airlift/esp32.py
@@ -147,10 +147,12 @@ class ESP32:
                 try:
                     print(startup_message.decode("utf-8"))
                 except UnicodeError:
-                    raise RuntimeError("Garbled ESP32 startup message") from UnicodeError
+                    raise RuntimeError(
+                        "Garbled ESP32 startup message"
+                    ) from UnicodeError
         else:
             raise RuntimeError("ESP32 did not respond with a startup message")
-        
+
         # Everything's fine. Remember mode.
         self._mode = mode
 

--- a/adafruit_airlift/esp32.py
+++ b/adafruit_airlift/esp32.py
@@ -136,10 +136,11 @@ class ESP32:
             return
 
         startup_message = b""
-        while self._uart.in_waiting:  # pylint: disable=no-member
-            more = self._uart.read()
-            if more:
-                startup_message += more
+        if self._uart is not None:
+            while self._uart.in_waiting:  # pylint: disable=no-member
+                more = self._uart.read()
+                if more:
+                    startup_message += more
 
         if not startup_message:
             raise RuntimeError("ESP32 did not respond with a startup message")


### PR DESCRIPTION
`stop_bluetooth()` sets _uart to None, so when calling `start_wifi()`, the call to reset that tries to read self._uart raises a Value Error. Check that _uart is not None