### PR TITLE
Don't check for startup message if no uart

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/pylint
-    rev: v2.17.4
+    rev: v3.1.0
     hooks:
       - id: pylint
         name: pylint (library code)


### PR DESCRIPTION
- Fixes #10 

Also fix documentation typos.

Tested on a PyPortal. The `start_wifi()` has limited utility because it doesn't work together with the ESP32SPI library. That's something else to think about in the future.